### PR TITLE
fix(eslint): add profile::mod with p6_return_words, use p6_string_space_pad for label alignment

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -160,5 +160,5 @@ p6df::modules::eslint::clones() {
 p6df::modules::eslint::profile::mod() {
 
   # shellcheck disable=SC2016
-  p6_return_words 'eslint' "$"
+  p6_return_words 'eslint' "$ESLINT_USE_FLAT_CONFIG"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -159,5 +159,6 @@ p6df::modules::eslint::clones() {
 ######################################################################
 p6df::modules::eslint::profile::mod() {
 
-  p6_return_words 'eslint' '$ESLINT_USE_FLAT_CONFIG'
+  # shellcheck disable=SC2016
+  p6_return_words 'eslint' "$"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -100,7 +100,7 @@ p6df::modules::eslint::prompt::line() {
   fi
 
   if p6_string_blank_NOT "$str"; then
-    str="eslint:\t\t  $str"
+    str="$(p6_string_space_pad "eslint:" 16)$str"
   fi
 
   p6_return_str "$str"
@@ -144,4 +144,20 @@ p6df::modules::eslint::clones() {
   p6_run_parallel "0" "4" "$(cat "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR"/p6df-js/conf/eslints)" "p6_git_p6_clone" "" "$P6_DFZ_SRC_FOCUSED_DIR"
 
   p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: words eslint $ESLINT_USE_FLAT_CONFIG = p6df::modules::eslint::profile::mod()
+#
+#  Returns:
+#	words - eslint $ESLINT_USE_FLAT_CONFIG
+#
+#  Environment:	 ESLINT_USE_FLAT_CONFIG
+#>
+######################################################################
+p6df::modules::eslint::profile::mod() {
+
+  p6_return_words 'eslint' '$ESLINT_USE_FLAT_CONFIG'
 }


### PR DESCRIPTION
## What
Adds `profile::mod` using `p6_return_words 'eslint' '$ESLINT_USE_FLAT_CONFIG'`. Updates `prompt::line` to use `p6_string_space_pad` for consistent label column alignment.

## Why
Implements the new `profile::mod` hook for prompt dispatch. Padding fix ensures eslint label aligns with other modules in the prompt.

## Test plan
- Source module and verify `profile::mod` is defined
- Verify prompt label is padded to 16 characters in `prompt::line`

## Dependencies
None