### PR TITLE
fix(init): use single quotes for ESLINT_USE_FLAT_CONFIG in profile::mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -159,6 +159,5 @@ p6df::modules::eslint::clones() {
 ######################################################################
 p6df::modules::eslint::profile::mod() {
 
-  # shellcheck disable=SC2016
-  p6_return_words 'eslint' "$ESLINT_USE_FLAT_CONFIG"
+  p6_return_words 'eslint' '$ESLINT_USE_FLAT_CONFIG'
 }


### PR DESCRIPTION
## What
Change double quotes to single quotes for `$ESLINT_USE_FLAT_CONFIG` in `profile::mod` and remove the now-unnecessary `shellcheck disable=SC2016` comment.

## Why
Single quotes are the correct form here to pass the literal variable name string rather than expanding it at call time. The shellcheck suppression was only needed for the double-quote form.

## Test plan
- Verified `init.zsh` loads without errors
- `profile::mod` now correctly returns the literal string `'$ESLINT_USE_FLAT_CONFIG'`

## Dependencies
None